### PR TITLE
Fix/serviceable param

### DIFF
--- a/src/app/actions/isServicable.ts
+++ b/src/app/actions/isServicable.ts
@@ -1,3 +1,5 @@
+import { ServiceableParams } from "../util/ServiceableForm";
+
 const servicableZipcodes = [
     "55555",
     "66666",
@@ -10,4 +12,6 @@ const servicableZipcodes = [
     "11111"
 ];
 
-export const isServicable = (zipcode: string): boolean => servicableZipcodes.includes(zipcode);
+export const isServicable = (zipcode: string): ServiceableParams => {
+    return servicableZipcodes.includes(zipcode) ? ServiceableParams.Serviceable : ServiceableParams.NonServiceable;
+};

--- a/src/app/actions/processZipcode.ts
+++ b/src/app/actions/processZipcode.ts
@@ -35,7 +35,7 @@ export async function processZipcode(
 
         // revalidate admin map if zipcode count % 100
 
-        redirect(`${paths.signup()}?servicable_form=${isServicable(zip)}`);
+        redirect(`${paths.signup()}?type=${isServicable(zip)}`);
 
     } catch (err: unknown) {
         if (isRedirectError(err)) {

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -1,18 +1,24 @@
 'use client';
 
-import { useSearchParams } from 'next/navigation';
-
 import EmailSignup from './EmailSignup';
 import AppointmentSignup from './AppointmentSignup';
+import { ServiceableParams } from '../util/ServiceableForm';
 
-export default function Signup() {
-    const searchParams = useSearchParams();
-    
-    const servicable = searchParams.get('servicable_form');
-    
+const ServiceableMap = {
+    [ServiceableParams.Serviceable]: <AppointmentSignup />,
+    [ServiceableParams.NonServiceable]: <EmailSignup />
+};
+
+type SignupPageParams = {
+    searchParams: {
+        type: ServiceableParams;
+    }
+}
+
+export default function Signup({searchParams}: SignupPageParams) { 
     return (
         <div>
-            { servicable ? <AppointmentSignup /> : <EmailSignup /> }
+            {ServiceableMap[searchParams.type]}
         </div>
     );
 }

--- a/src/app/util/ServiceableForm.ts
+++ b/src/app/util/ServiceableForm.ts
@@ -1,0 +1,4 @@
+export enum ServiceableParams {
+    Serviceable = "serviceable",
+    NonServiceable = "non-serviceable"
+};


### PR DESCRIPTION
Added `serviceable` and `non-serviceable` enums to wrap query param and properly redirect to `EmailSignup` or `AppointmentSignup` forms from the main page.

Now the link looks like http://localhost:3000/signup?type=serviceable for zipcode being in a serviceable range and http://localhost:3000/signup?type=non-serviceable for not-serviceable one.